### PR TITLE
Fix StringIndexError when extracting section info

### DIFF
--- a/src/html.jl
+++ b/src/html.jl
@@ -68,7 +68,7 @@ function section_infos(text)
         if !isnothing(m)
             number, id = m.captures 
             line_end = split(line, '>')[end-1]
-            text = line_end[2:end-4]
+            text = line_end[nextind(line_end, 0, 2):prevind(line_end, end, 4)]
             tuple = (num = number, id = id, text = lstrip(text))
             push!(tuples, tuple)
         end
@@ -76,7 +76,7 @@ function section_infos(text)
         if !isnothing(m)
             id = m.captures[1]
             interesting_region = split(line, '>')[end-1]
-            text = interesting_region[1:end-4]
+            text = interesting_region[nextind(interesting_region, 0, 1):prevind(interesting_region, end, 4)]
             tuple = (num = "", id = id, text = lstrip(text))
             push!(tuples, tuple)
         end

--- a/test/html.jl
+++ b/test/html.jl
@@ -48,4 +48,8 @@
 
     names = B.html_page_names(bodies)
     @test names == ["welcome", "getting-started", "something", "embedding-code"]
+
+    text = "<h1 data-number=\"1\" id=\"前言\"><span class=\"header-section-number\">1</span> 前言</h1>"
+    tuples = B.section_infos(text)
+    @test tuples[1] == (num = "1", id = "前言", text = "前言")
 end


### PR DESCRIPTION
This will fix the `StringIndexError` when the header contains some non-ASCII characters

Ref: https://docs.julialang.org/en/v1/manual/strings/#Unicode-and-UTF-8