### PR TITLE
Fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ julia> using Books
 julia> pdf()
 ```
 
-For more information, see the [documentation](https://books.huijzer.xyz).
+For more information, see the [documentation](https://rikhuijzer.github.io/Books.jl/).


### PR DESCRIPTION
Besides, the following line also needs to be updated with a `url-prefix`:

https://github.com/rikhuijzer/Books.jl/blob/ef419b64d59f526787fb62192a9c417bab6c323b/src/html.jl#L153