### PR TITLE
Also generate content for homepage

### DIFF
--- a/defaults/config.toml
+++ b/defaults/config.toml
@@ -21,6 +21,10 @@
   # Port used by serve().
   port = 8010
 
+  # For large books, it can be nice to show some information on the homepage
+  # which is only visible to online visitors and hidden from book readers (PDF).
+  include_homepage_outside_html = false
+
 
 
   # Alternative project, used when calling, for example, serve(project="dev").
@@ -44,3 +48,5 @@
   extra_directories = [
     "images"
   ]
+
+  include_homepage_outside_html = false

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,9 +7,11 @@ version = "0.1.0"
 Books = "939d5c6b-51ae-42e7-97ca-7564d0d4ad91"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 CodeTracking = "1.0"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -16,3 +16,8 @@
   extra_directories = [
     "images"
   ]
+
+  port = 8012
+
+  # The homepage of docs shows some verion info which is nice for the PDF too.
+  include_homepage_outside_html = true

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -2,7 +2,9 @@
 
 [//]: # (This file is only included on the website.)
 
-This website introduces and demonstrates the package [Books.jl](https://github.com/rikhuijzer/Books.jl){target="_blank"} and is available as [**PDF**](/books.pdf){target="_blank"} and [docx](/books.docx){target="_blank"}
+```{.include}
+_gen/homepage_intro.md
+```
 
 See @sec:about for more information about this package.
 To get started and setup your own project, see @sec:getting-started.

--- a/docs/src/BooksDocs.jl
+++ b/docs/src/BooksDocs.jl
@@ -2,10 +2,12 @@ module BooksDocs
 
 import Latexify
 import Statistics
+import TOML
 
 using Books
 using CodeTracking
 using DataFrames
+using Dates
 using Gadfly
 
 include("includes.jl")

--- a/docs/src/includes.jl
+++ b/docs/src/includes.jl
@@ -1,3 +1,14 @@
+function homepage_intro()
+    books_project_path = joinpath(pkgdir(Books), "Project.toml")
+    project_info = read(books_project_path, String)
+    project_info = TOML.parse(project_info)
+
+    books_version = project_info["version"]
+    text = """
+    This website introduces and demonstrates the package [Books.jl](https://github.com/rikhuijzer/Books.jl){target="_blank"} at version $books_version and is available as [**PDF**](/books.pdf){target="_blank"} and [docx](/books.docx){target="_blank"}.
+    These pages were built on $(today()) with Julia $VERSION.
+    """
+end
 serve_example() = code_block(raw"""
     $ julia --project -e 'using Books; serve()'
     Watching ./pandoc/favicon.png

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -71,15 +71,10 @@ Read user `config.toml` and `$DEFAULTS_DIR/config.toml` and combine the informat
 ```jldoctest
 julia> cd(joinpath(pkgdir(Books), "docs"))
 
-julia> Books.config("default")
-Dict{String, Any} with 7 entries:
-  "homepage_contents" => "index"
-  "metadata_path"     => "metadata.yml"
-  "port"              => 8010
-  "contents"          => ["about", "getting-started", "demo", "references"]
-  "output_filename"   => "books"
-  "online_url_prefix" => "Books.jl"
-  "extra_directories" => ["images"]
+julia> c = Books.config("default");
+
+julia> c["port"]
+8012
 ```
 """
 function config(project::AbstractString)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -15,7 +15,7 @@ Returns the filenames mentioned in `{.include}` code blocks.
 function include_filenames(s::AbstractString)::Vector
     matches = eachmatch(include_regex, s)
     nested_filenames = [split(m[1]) for m in matches]
-    vcat(nested_filenames...) 
+    vcat(nested_filenames...)
 end
 
 """


### PR DESCRIPTION
Fixes https://github.com/rikhuijzer/Books.jl/issues/72.

This issue got me down a bit of a spiral. The user can now also specify 
```
include_homepage_outside_html = true
```
which will ensure that the homepage contents are added to offline documents like PDF too. 

However, then the question is how to ensure that the homepage is easily accessible for the user. That is, to not only hide it behind the home button, but also show it as a section in the menu. This is opened as a new issue: https://github.com/rikhuijzer/Books.jl/issues/99.