### PR TITLE
Add scob

### DIFF
--- a/defaults/style.css
+++ b/defaults/style.css
@@ -227,7 +227,7 @@ hr {
 }
 
 pre, code, kbd, samp {
-  font-family: JuliaMono-Regular;
+  font-family: "JuliaMono-Regular", "SFMono-Regular", "DejaVu Sans Mono";
   font-size: var(--small-size);
   color: #000;
   background: var(--block-background);

--- a/defaults/style.css
+++ b/defaults/style.css
@@ -5,7 +5,8 @@
   --normal-size: 19px;
   --small-size: 14px;
   --tiny-size: 11px;
-  --block-background: hsl(0, 0%, 97%);
+  --block-background: hsl(0, 0%, 94%);
+  --output-background: hsl(120, 100%, 94%);
   --menu-width: 220px;
   --max-body-width: 960px;
   --content-left-margin: 70px;
@@ -230,18 +231,29 @@ pre, code, kbd, samp {
   font-size: var(--small-size);
   color: #000;
   background: var(--block-background);
-  margin-top: 1.2em;
-  margin-bottom: 1.2em;
-  padding-top: 0.5em;
-  padding-left: 0.2em;
-  padding-bottom: 0.5em;
-  border-radius: 8px;
+  margin-top: 0.6em;
+  margin-bottom: 0.6em;
+  padding-top: 0.3em;
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+  padding-bottom: 0.3em;
+  border-radius: 4px;
 }
 
 pre {
   white-space: pre;
   white-space: pre-wrap;
   word-wrap: break-word;
+  border: 1px solid #dbdbdb;
+}
+
+pre.output {
+  background: hsl(0, 0%, 98%);
+  border: 1px dashed #dbdbdb;
+}
+
+.output code {
+  background: hsl(0, 0%, 98%);
 }
 
 b, strong {

--- a/docs/contents/demo.md
+++ b/docs/contents/demo.md
@@ -78,8 +78,7 @@ julia> gen()
 To run this method automatically when you make a change in your package, ensure that you loaded [Revise.jl](https://github.com/timholy/Revise.jl) before loading your package and run
 
 ```
-julia> entr(gen, ["contents"], [M])
-[...]
+entr(gen, ["contents"], [M])
 ```
 
 where M is the name of your module.
@@ -269,7 +268,7 @@ It is also possible to show methods with parameters.
 ```
 
 ```jl
-sco("""
+scob("""
 M.hello("World")
 """)
 ```
@@ -368,6 +367,23 @@ To write note boxes, you can use
 
 This way is fully supported by Pandoc, so it will be correctly converted to outputs such as PDF or DOCX.
 
-### String interpolation
+### scob
 
-For string interpolation, add a backslash before the dollar sign when using `sc` or `sco`.
+To enforce output to be embedded inside a code block, use `scob`.
+For example,
+
+```jl
+sco("""
+scob("
+df = DataFrame(A = [1], B = [Date(2018)])
+string(df)
+")
+""")
+```
+
+or, with a string
+
+```jl
+scob("s = \"Hello\"")
+```
+

--- a/docs/src/includes.jl
+++ b/docs/src/includes.jl
@@ -112,7 +112,7 @@ function markdown_gen_example()
     gen("index")
     ```
 
-    ```
+    ```output
     $(rstrip(c.output))
     Updating html
     ```

--- a/src/Books.jl
+++ b/src/Books.jl
@@ -30,8 +30,8 @@ include("generate.jl")
 
 export html, pdf, docx, build_all
 export code, ImageOptions, Options
-export code_block
-export @sc, sc, CodeAndFunction, @sco, sco
+export code_block, output_block
+export @sc, sc, CodeAndFunction, @sco, sco, scob
 export gen
 export serve
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -101,6 +101,7 @@ function pandoc_html(project::AbstractString)
     metadata = "--metadata-file=$metadata_path"
     copy_css()
     copy_mousetrap()
+    copy_juliamono()
 
     args = [
         inputs(project);

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -6,6 +6,13 @@ Wrap `s` in a Markdown code block with triple backticks.
 """
 code_block(s) = "```\n$s\n```\n"
 
+"""
+    output_block(s)
+
+Wrap `s` in a Markdown code block with the language description "output".
+"""
+output_block(s) = "```output\n$s\n```\n"
+
 function extract_codeblock_expr(s)
 end
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -35,7 +35,7 @@ end
 
 function convert_output(expr, path, outputs::AbstractVector{AbstractString})
     out = join(outputs, "\n")
-    out = code_block(out)
+    out = output_block(out)
 end
 
 function convert_output(expr, path, outputs::AbstractVector)
@@ -44,7 +44,7 @@ function convert_output(expr, path, outputs::AbstractVector)
     # because it would be hard to read.
     if t <: AbstractString || t <: Number
         out = string(outputs)::String
-        out = code_block(out)
+        out = output_block(out)
     else
         path = nothing
         outputs = convert_output.(nothing, nothing, outputs)
@@ -100,7 +100,7 @@ function convert_output(expr, path, out::Code)::String
     end
     shown_output = convert_output(expr, path, ans)
     if isa(ans, AbstractString) || isa(ans, Number)
-        shown_output = code_block(shown_output)
+        shown_output = output_block(shown_output)
     end
 
     mod_info = mod == Main || out.hide_module ? "" :
@@ -219,7 +219,7 @@ function convert_output(expr, path, out)::String
     show(io, mime, out)
     out = String(take!(io))
     # This is required for MCMCChains, but it would be nicer if the user could specify this.
-    out = code_block(out)
+    out = output_block(out)
 end
 
 """
@@ -362,5 +362,5 @@ function doctest(s::Markdown.MD)
     lines = split(content, '\n')
     lines = lines[2:end-1]
     content = join(lines, '\n')
-    code_block(content)
+    output_block(content)
 end

--- a/src/showcode.jl
+++ b/src/showcode.jl
@@ -72,18 +72,30 @@ function eval_convert(expr::AbstractString, M)
 end
 
 """
-    sco(expr::AbstractString; M=Main)
+    sco(expr::AbstractString; M=Main, post::Function=identity)
 
 Show code and output for `expr`.
+Post-process the output by applying `post` to it.
 """
-function sco(expr::AbstractString; M=Main)
-    out = eval_convert(expr, M)
+function sco(expr::AbstractString; M=Main, post::Function=identity)
     code = remove_hide_comment(expr)
     code = code_block(strip(code))
+    out = eval_convert(expr, M)
+    out = post(out)
     """
     $code
     $out
     """
+end
+
+"""
+    scob(expr::AbstractString; M=Main)
+
+Show code and output in a block for `expr`.
+"""
+function scob(expr::AbstractString; M=Main)
+    post = output_block
+    sco(expr; M, post)
 end
 
 """

--- a/test/output.jl
+++ b/test/output.jl
@@ -1,5 +1,5 @@
 @testset "output" begin
     V = ["a", "b"]
     out = Books.convert_output(missing, missing, V)
-    @test out == code_block(string(V))
+    @test out == output_block(string(V))
 end


### PR DESCRIPTION
Closes #143 by adding a `scob` method.

Also fixes JuliaMono and improves the appearance of code blocks and output considerably.

