### PR TITLE
Fix third level indent

### DIFF
--- a/docs/contents/demo.md
+++ b/docs/contents/demo.md
@@ -482,4 +482,11 @@ For example, this will show as:
    scob("x = 2 + 1")
    ```
 
-2. And the list continues.
+2. And the list continues
+    * with an example on the third level:
+
+       ```jl
+       scob("x = 3 + 1")
+       ```
+
+    * another third level item

--- a/src/build.jl
+++ b/src/build.jl
@@ -98,6 +98,9 @@ function codeblock2output(s::AbstractString)
     output_path = escape_expr(expr)
     if isfile(output_path)
         output = read(output_path, String)
+        # The indentation of the first line is already handled somewhere else
+        # (probably by the regex).
+        output = lstrip(output)
         return output
     else
         msg = """

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -29,7 +29,7 @@ output_block(s) = "```output\n$s\n```\n"
 
 Pattern to match `jl` code blocks.
 """
-CODEBLOCK_PATTERN = r"```jl\s*([^```]*)\n([ ]*)```\n(?!</pre>)"
+const CODEBLOCK_PATTERN = r"```jl\s*([^```]*)\n([ ]*)```\n(?!</pre>)"
 
 const INLINE_CODEBLOCK_PATTERN = r" `jl ([^`]*)`"
 
@@ -286,13 +286,14 @@ function gen(paths::Vector{String};
     for expr in included_expr
         out = evaluate_include(expr, M, fail_on_error)
         if out isa InterruptException
-            break
+            return nothing
         end
     end
     if call_html
         println("Updating html")
         html(; project)
     end
+    return nothing
 end
 
 """

--- a/test/build.jl
+++ b/test/build.jl
@@ -58,4 +58,29 @@
         catch
         end
     end
+
+    out = cd(docs_dir) do
+        test_markdown_path = joinpath(docs_dir, "contents", "test.md")
+        third_level_indentation = """
+            1. This is the second level
+                * This is the third level
+
+                   ```jl
+                   s = "x = 1 + 2"
+                   sco(s)
+                   ```
+
+                * Another item
+            """
+        write(test_markdown_path, third_level_indentation)
+
+        mkpath(joinpath(Books.BUILD_DIR, "images"))
+        gen("test"; project="test")
+        out = Books.embed_output(third_level_indentation)
+
+        lines = split(out, '\n')
+        # Due to, probably, the Regex, it can happen that the first line gets indented too much.
+        @test lines[4] == "       ```language-julia"
+        @test lines[5] == "       x = 1 + 2"
+    end
 end


### PR DESCRIPTION
Code blocks on the third level in lists were evaluated but the output was wrong. Specifically, it was indented too much, causing Pandoc to interpret it incorrectly.