### PR TITLE
Add pre keyword to @sco and sco

### DIFF
--- a/docs/contents/demo.md
+++ b/docs/contents/demo.md
@@ -257,6 +257,29 @@ resulting in
 @sc M.my_data()
 ```
 
+To override options for your output, use the `pre` keyword argument of `@sco`:
+
+<pre class="language-julia">
+```jl
+let
+    caption = "This caption is set via the pre keyword."
+    pre(out) = Options(out; caption)
+    @sco pre=pre my_data()
+end
+```
+</pre>
+
+which appears to the reader as:
+
+```jl
+let
+    caption = "This caption is set via the pre keyword."
+    pre(out) = Options(out; caption)
+    @sco pre=pre my_data()
+end
+```
+
+See `?sco` for more information.
 Since we're using methods as code blocks, we can use the code shown in one code block in another.
 For example, to determine the mean of column A:
 

--- a/src/Books.jl
+++ b/src/Books.jl
@@ -10,7 +10,6 @@ end
 
 import Artifacts
 import CodeTracking
-import InteractiveUtils
 import LiveServer
 import Markdown
 import Tectonic
@@ -19,6 +18,7 @@ import YAML
 import pandoc_crossref_jll
 
 using Dates: today
+using InteractiveUtils: gen_call_with_extracted_types
 using Memoize
 using Requires
 using pandoc_jll

--- a/src/showcode.jl
+++ b/src/showcode.jl
@@ -96,6 +96,24 @@ Specifically,
 - `pre` is applied before `convert_output`
 - `process` is applied instead of `convert_output`
 - `post` is applied after convert output
+
+For example, for
+```julia
+let
+    pre(out) = Options(out; label="l")
+    post = string
+    sco("DataFrame(x = [1])"; pre, post)
+end
+```
+
+the DataFrame will go through three stages:
+
+1. `pre` adds the label "l" to the object
+1. `process` is nothing, so `convert_output` will do its usual suff, namely converting
+    the DataFrame object to Markdown.
+1. `post` converts the output to a string (even though this is already done by `convert_output` in this case).
+
+So, to disable `convert_output`, pass `process=nothing` or `process=identity`.
 """
 function sco(expr::AbstractString;
         M=Main,

--- a/test/showcode.jl
+++ b/test/showcode.jl
@@ -1,4 +1,6 @@
 sc_test_function() = 1
+sco_test_dataframe() = DataFrame(; x = [1])
+
 function sc_test_function_with_comment()
     x = 1 # hide
     return 2
@@ -62,4 +64,22 @@ end
     with_macro = remove_line(with_macro, 2)
 
     @test with_macro == without_macro
+end
+
+@testset "@sco" begin
+    pre(out) = Options(out; caption="caption")
+    df = DataFrame(; x = [1, 2])
+    s = @sco pre=pre sco_test_dataframe()
+    @test strip(s) == strip("""
+        ```language-julia
+        sco_test_dataframe() = DataFrame(; x = [1])
+        sco_test_dataframe()
+        ```
+
+        |   x |
+        | ---:|
+        |   1 |
+
+        : caption
+        """)
 end

--- a/test/showcode.jl
+++ b/test/showcode.jl
@@ -68,7 +68,6 @@ end
 
 @testset "@sco" begin
     pre(out) = Options(out; caption="caption")
-    df = DataFrame(; x = [1, 2])
     s = @sco pre=pre sco_test_dataframe()
     @test strip(s) == strip("""
         ```language-julia


### PR DESCRIPTION
Thanks to the pre keyword, we can wrap options around any object:

```
function my_func()
    return DataFrame(; x = [1])
end
```

    ```jl
    pre(out) = Options(out; caption="Caption")
    @sco pre=pre my_func()
    ```