### PR TITLE
Make `@sc` more reliable

### DIFF
--- a/src/showcode.jl
+++ b/src/showcode.jl
@@ -18,9 +18,9 @@ Show code for function `f`; to also show output, use [`@sco`](@ref).
 """
 macro sc(f)
     esc(quote
-        s = Books.CodeTracking.@code_string $(f)
-        s = Books.remove_hide_comment(s)
-        Books.code_block(s)
+        s = $CodeTracking.@code_string $(f)
+        s = $remove_hide_comment(s)
+        $code_block(s)
     end)
 end
 

--- a/test/showcode.jl
+++ b/test/showcode.jl
@@ -82,3 +82,19 @@ end
         : caption
         """)
 end
+
+module ShowcodeTestModule
+
+using Books: @sc
+using Test
+
+f(x) = 2x
+
+@testset "showcode_from_module" begin
+    # Test that @sc works with minimal imports on the user side.
+    f_def = @sc f(1)
+    @test contains(f_def, "2x")
+end
+
+end # module
+


### PR DESCRIPTION
These changes ensure that `@sc` also works when the user did `using Books: foo` instead of `using Books` (with the former, `Books` is undefined in the module).