### PR TITLE
Explicitly load symbols

### DIFF
--- a/src/Books.jl
+++ b/src/Books.jl
@@ -11,17 +11,17 @@ end
 import Artifacts
 import CodeTracking
 import LiveServer
-import Markdown
-import Tectonic
 import TOML
 import YAML
-import pandoc_crossref_jll
 
 using Dates: today
 using InteractiveUtils: gen_call_with_extracted_types
-using Memoize
-using Requires
-using pandoc_jll
+using Markdown: MD
+using Memoize: @memoize
+using Requires: @require
+using Tectonic: tectonic
+using pandoc_crossref_jll: pandoc_crossref_path
+using pandoc_jll: pandoc
 
 const GENERATED_DIR = "_gen"
 const DEFAULTS_DIR = joinpath(PROJECT_ROOT, "defaults")

--- a/src/build.jl
+++ b/src/build.jl
@@ -1,4 +1,4 @@
-const crossref_bin = string(pandoc_crossref_jll.pandoc_crossref_path)::String
+const crossref_bin = string(pandoc_crossref_path)::String
 const crossref = "--filter=$crossref_bin"
 const include_lua_filter = joinpath(PROJECT_ROOT, "src", "include-codeblocks.lua")
 const include_files = "--lua-filter=$include_lua_filter"
@@ -302,7 +302,7 @@ function pdf(; project="default")
     input_files = ignore_homepage(project, inputs(project))
     juliamono_template_var = "--variable=juliamono-path:$JULIAMONO_PATH"
 
-    Tectonic.tectonic() do tectonic_bin
+    tectonic() do tectonic_bin
         pdf_engine = "--pdf-engine=$tectonic_bin"
 
         args = [

--- a/src/output.jl
+++ b/src/output.jl
@@ -368,12 +368,12 @@ function caption_label(expr, caption, label)
 end
 
 """
-    docstring(s::Markdown.MD)
+    docstring(s::MD)
 
 Return docstring, as obtained from `@doc f` for function `f`, to be parsed by Pandoc.
 Needs work to be made prettier.
 """
-function docstring(s::Markdown.MD)
+function docstring(s::MD)
     lines = split(string(s), '\n')
     ignore(line) = any([
         contains(line, "```")
@@ -389,11 +389,11 @@ function docstring(s::Markdown.MD)
 end
 
 """
-    doctest(s::Markdown.MD)
+    doctest(s::MD)
 
 Return jldoctest, as obtained from `@doc f` for function `f`.
 """
-function doctest(s::Markdown.MD)
+function doctest(s::MD)
     s = string(s)
     start = findfirst("```jldoctest", s).start
     stop = findlast("```", s).stop

--- a/src/outputs/aog.jl
+++ b/src/outputs/aog.jl
@@ -1,7 +1,6 @@
 @debug "Loading AlgebraOfGraphics.jl support into Books.jl via Requires.jl"
 
-using AlgebraOfGraphics
-using CairoMakie
+import AlgebraOfGraphics
 
 function convert_output(
         expr,

--- a/src/outputs/makie.jl
+++ b/src/outputs/makie.jl
@@ -1,7 +1,6 @@
 @debug "Loading Makie.jl support into Books.jl via Requires.jl"
 
-using CairoMakie
-import Makie
+using Makie: FileIO
 
 function convert_output(
         expr,
@@ -22,7 +21,7 @@ function convert_output(
     # Explicit rm due to https://github.com/JuliaIO/FileIO.jl/issues/338.
     rm(png_path; force=true)
     px_per_unit = 3 # Ensure high resolution.
-    Makie.FileIO.save(png_path, p; px_per_unit)
+    FileIO.save(png_path, p; px_per_unit)
 
     svg_filename = "$file.svg"
     svg_path = joinpath(im_dir, svg_filename)
@@ -30,7 +29,7 @@ function convert_output(
     im_link = joinpath("im", svg_filename)
     try
         # SVG doesn't work with GLMakie.
-        Makie.FileIO.save(svg_path, p)
+        FileIO.save(svg_path, p)
     catch
         # Even when the SVG saving fails, Makie creates an image of 0 bytes.
         rm(svg_path; force=true)

--- a/src/outputs/plots.jl
+++ b/src/outputs/plots.jl
@@ -1,6 +1,6 @@
 @debug "Loading Plots.jl support into Books.jl via Requires.jl"
 
-import Plots
+using Plots: savefig
 
 function convert_output(
         expr,
@@ -18,11 +18,11 @@ function convert_output(
     println("Writing plot images for $file")
     svg_filename = "$file.svg"
     svg_path = joinpath(im_dir, svg_filename)
-    Plots.savefig(p, svg_path)
+    savefig(p, svg_path)
 
     png_filename = "$file.png"
     png_path = joinpath(im_dir, png_filename)
-    Plots.savefig(p, png_path)
+    savefig(p, png_path)
 
     im_link = joinpath("im", svg_filename)
     caption, label = caption_label(expr, caption, label)

--- a/test/output.jl
+++ b/test/output.jl
@@ -8,7 +8,7 @@
     # Without escaping the underscores (_), Latexify would change _ to *.
     @test contains(out, "foo_bar_baz")
 
-    p = Makie.lines(1:30)
+    p = lines(1:30)
     filename = "makietest"
     opts = Options(p; filename)
     out = Books.convert_output(missing, missing, opts)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,13 @@
 import Pkg
 
-import Makie
-
 using Books
+using CairoMakie
 using DataFrames
 using Dates: today
-using Documenter
+using Documenter:
+    DocMeta,
+    doctest
+using Makie: lines
 using Test
 
 B = Books


### PR DESCRIPTION
For more info, see <https://jump.dev/JuMP.jl/v0.21/developers/style/#using-vs.-import>.