### PR TITLE
Enable colorlinks and improve syntax highlighting

### DIFF
--- a/defaults/template.tex
+++ b/defaults/template.tex
@@ -284,7 +284,7 @@ $if(footnotes-pretty)$
 \setlength{\skip\footins}{0.3cm} % set space between page content and footnote
 \setlength{\footskip}{0.9cm} % set space between footnote and page bottom
 $endif$
-\definecolor{linkblue}{HTML}{3343a6}
+\definecolor{linkblue}{HTML}{3D93F6}
 \usepackage{hyperref}
 \hypersetup{
   colorlinks,

--- a/defaults/template.tex
+++ b/defaults/template.tex
@@ -284,8 +284,13 @@ $if(footnotes-pretty)$
 \setlength{\skip\footins}{0.3cm} % set space between page content and footnote
 \setlength{\footskip}{0.9cm} % set space between footnote and page bottom
 $endif$
-\IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
+\definecolor{linkblue}{HTML}{3343a6}
+\usepackage{hyperref}
 \hypersetup{
+  colorlinks,
+  citecolor=linkblue,
+  linkcolor=linkblue,
+  urlcolor=linkblue,
 $if(title-meta)$
   pdftitle={$title-meta$},
 $endif$
@@ -301,17 +306,9 @@ $endif$
 $if(keywords)$
   pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
 $endif$
-$if(colorlinks)$
-  colorlinks=true,
-  linkcolor=$if(linkcolor)$$linkcolor$$else$default-linkcolor$endif$,
-  filecolor=$if(filecolor)$$filecolor$$else$default-filecolor$endif$,
-  citecolor=$if(citecolor)$$citecolor$$else$default-citecolor$endif$,
-  urlcolor=$if(urlcolor)$$urlcolor$$else$default-urlcolor$endif$,
-$else$
-  hidelinks,
-$endif$
   breaklinks=true,
-  pdfcreator={LaTeX via pandoc with the Eisvogel template}}
+  pdfcreator={LaTeX via Pandoc}%
+}
 \urlstyle{same} % disable monospaced font for URLs
 $if(verbatim-in-note)$
 \VerbatimFootnotes % allow verbatim text in footnotes
@@ -337,15 +334,10 @@ $if(beamer)$
 $endif$
 \usepackage{listings}
 \newcommand{\passthrough}[1]{#1}
-\lstset{defaultdialect=[5.3]Lua}
-\lstset{defaultdialect=[x86masm]Assembler}
 $if(listings-no-page-break)$
 \usepackage{etoolbox}
 \BeforeBeginEnvironment{lstlisting}{\par\noindent\begin{minipage}{\linewidth}}
 \AfterEndEnvironment{lstlisting}{\end{minipage}\par\addvspace{\topskip}}
-$endif$
-$if(lhs)$
-\lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
 $endif$
 $if(highlighting-macros)$
 $highlighting-macros$
@@ -725,12 +717,14 @@ $endif$
 \definecolor{listing-string}{HTML}{00999A}
 \definecolor{listing-comment}{HTML}{8E8E8E}
 
-%
-% Better no syntax highlighting than wrong syntax highlighting.
-%
-\lstdefinelanguage{raw}{
-  keywordstyle=\ttfamily
-}
+% Override the color for inline code.
+% source: https://tex.stackexchange.com/questions/124115
+\usepackage{etoolbox}
+\usepackage{atbegshi,ifthen,tikz}
+\usepackage[most]{tcolorbox}
+
+\let\lstinlineoriginal=\lstinline
+\renewcommand{\lstinline}{\lstinlineoriginal[keywordstyle=\color{gray}]}
 
 % Use for debugging
 % \show\ttfamily{}
@@ -4041,15 +4035,24 @@ $endif$
 \lst@RestoreCatcodes
 \makeatother
 
+\definecolor{highlight-red}{HTML}{d73a49}
+\definecolor{highlight-background}{HTML}{f5f5f5}
+% Inline code should have a gray background.
+% That's not working (yet), so making the font color a bit more light.
+% The website uses hsl(0, 0, 15) == #262626
+\definecolor{highlight-gray}{HTML}{333333}
+\definecolor{highlight-blue}{HTML}{005cc5}
+\definecolor{highlight-darkblue}{HTML}{032f62}
+
 \lstdefinestyle{eisvogel_listing_style}{
   language         = Julia,
-  backgroundcolor  = \color[HTML]{fafafa},
-  basicstyle       = \JuliaMonoRegular\small\color[HTML]{19177C},
-  numberstyle      = \JuliaMonoRegular\scriptsize\color[HTML]{7F7F7F},
-  keywordstyle     = [1]{\JuliaMonoBold\color[HTML]{1BA1EA}},
-  keywordstyle     = [2]{\color[HTML]{0F6FA3}},
-  keywordstyle     = [3]{\color[HTML]{0000FF}},
-  stringstyle      = \JuliaMonoRegular\color[HTML]{F5615C},
+  backgroundcolor  = \color{highlight-background},
+  basicstyle       = \JuliaMonoRegular\small\color{highlight-gray},
+  numberstyle      = \JuliaMonoRegular\scriptsize\color{highlight-blue},
+  keywordstyle     = [1]{\JuliaMonoBold\color{highlight-darkblue}},
+  keywordstyle     = [2]{\color{highlight-darkblue}},
+  keywordstyle     = [3]{\color{highlight-darkblue}},
+  stringstyle      = \JuliaMonoRegular\color{highlight-darkblue},
   commentstyle     = \color[HTML]{AAAAAA},
   rulecolor        = \color[HTML]{000000},
   xleftmargin      = 0.6em,

--- a/docs/contents/about.md
+++ b/docs/contents/about.md
@@ -1,6 +1,6 @@
 # About {#sec:about}
 
-Similar to [Bookdown](https://bookdown.org){target="_blank"} this package is, basically, a wrapper around [Pandoc](https://pandoc.org/){target="_blank"}.
+Similar to [Bookdown](https://bookdown.org){target="_blank"}, this package wraps around [Pandoc](https://pandoc.org/){target="_blank"}.
 For websites, this package allows for:
 
 - Building a website spanning multiple pages.
@@ -9,7 +9,7 @@ For websites, this package allows for:
 - Embedding dynamic output, while still allowing normal Julia package utilities, such as unit testing and live reloading (Revise.jl).
 - Showing code blocks as well as output.
 
-If you don't need PDFs or EPUBs, then [Franklin.jl](https://github.com/tlienart/Franklin.jl){target="_blank"} is probably a better choice.
+If you don't need to generate PDFs, then [Franklin.jl](https://github.com/tlienart/Franklin.jl){target="_blank"} is probably a better choice.
 To create single pages and PDFs containing code blocks, see [Weave.jl](https://github.com/JunoLab/Weave.jl){target="_blank"}.
 
 One of the main differences with Franklin.jl, Weave.jl and knitr (Bookdown) is that this package completely decouples the computations from the building of the output.


### PR DESCRIPTION
Enables colored links for cross-references etc.

Also, makes the appearance of syntax highlighting in HTML and PDF more consistent.

# HTML

![image](https://user-images.githubusercontent.com/20724914/133930009-1b14bb43-7cb3-4014-a477-8c92ca1a88c3.png)

# PDF before PR

![image](https://user-images.githubusercontent.com/20724914/133930053-3b8c85e6-f5fd-442a-82b3-5e80d87c9c56.png)

# PDF after PR

![image](https://user-images.githubusercontent.com/20724914/133930074-67d87476-622c-44a8-b7e1-820dd157885f.png)
