### PR TITLE
Improve undefined cross-reference error

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -163,7 +163,11 @@ end
 function verify_cross_references(h)
     # For example, "<strong>¿sec:about?</strong>"
     if contains(h, "<strong>¿")
-        error("Output contains undefined cross-references:\n$h")
+        rx = r"<strong>¿([^<]*)\?</strong>"
+        matches = collect(eachmatch(rx, h))
+        refs = ["- " * m[1] for m in matches]
+        missing_crossrefs = join(refs, "\n")
+        error("Output contains undefined cross-references:\n\n$missing_crossrefs\n")
     end
 end
 


### PR DESCRIPTION
Instead of printing the **full** HTML, the error is now simply:
```
julia> html(; fail_on_error=true)
Undefined cross-reference: fig:stats_vs_prob
ERROR: Output contains undefined cross-references:

- fig:stats_vs_prob

Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] verify_cross_references(h::String)
   @ Books ~/git/Books.jl/src/build.jl:170
 [3] pandoc_html(project::String; fail_on_error::Bool)
   @ Books ~/git/Books.jl/src/build.jl:203
 [4] html(; project::String, extra_head::String, fail_on_error::Bool, build_sitemap::Bool)
   @ Books ~/git/Books.jl/src/build.jl:268
 [5] top-level scope
   @ REPL[19]:1
```