### PR TITLE
Pre fix

### DIFF
--- a/defaults/metadata.yml
+++ b/defaults/metadata.yml
@@ -44,7 +44,7 @@ link-citations: true
 
 # These table of contents settings only affect the PDF.
 toc: true
-toc-depth: 2
+tocdepth: 1
 
 # Cross-reference prefixes.
 eqnPrefix: Equation

--- a/defaults/template.tex
+++ b/defaults/template.tex
@@ -219,9 +219,10 @@ $endif$
 \frontmatter
 \mainmatter
 
-\setcounter{tocdepth}{$toc-depth$}
-
+$if(toc)$
+\setcounter{tocdepth}{$tocdepth$}
 \tableofcontents
+$endif$
 
 % Justify text.
 \justifying

--- a/docs/contents/about.md
+++ b/docs/contents/about.md
@@ -39,31 +39,23 @@ In combination with Revise.jl, you can quickly update your code and see the upda
 Finally, a big difference with this package and other packages is that you decide yourself what you want to show for a code block.
 For example, in R
 
-<pre>
-```{r, results='hide'}
-print("Hello, world!")
-```
-</pre>
+    ```{r, results='hide'}
+    print("Hello, world!")
+    ```
 
 shows the code and not the output.
 Instead, in Books, you would write
 
-<pre>
-```jl
-sc(raw"""
-print("Hello, world!")
-"""
-)
-```
-</pre>
+    ```jl
+    s = """print("Hello, world!")"""
+    sc(s)
+    ```
 
 which is displayed as
 
 ```jl
-sc(raw"""
-print("Hello, world!")
-"""
-)
+s = """print("Hello, world!")"""
+sc(s)
 ```
 
 Here, `sc` is one of the convenience methods exported by Books.jl.
@@ -71,15 +63,13 @@ Although this approach is more verbose in some cases, it is also much more flexi
 In essence, you can come up with your own pre- or post-processing logic.
 For example, lets write
 
-<pre>
-```jl
-code = """
-    df = DataFrame(a=[1, 2], b=[3, 4])
-    Options(df, caption="A table.", label=nothing)
-    """
-repeat(sco(code), 4)
-```
-</pre>
+    ```jl
+    code = """
+        df = DataFrame(a=[1, 2], b=[3, 4])
+        Options(df, caption="A table.", label=nothing)
+        """
+    repeat(sco(code), 4)
+    ```
 
 which shows the code and output (`sco`) 4 times:
 
@@ -90,5 +80,4 @@ code = """
     """
 repeat(sco(code), 4)
 ```
-
 

--- a/docs/contents/demo.md
+++ b/docs/contents/demo.md
@@ -102,11 +102,9 @@ To show that a DataFrame is converted to a Markdown table, we define a method
 
 and add its output to the Markdown file with
 
-<pre class="language-julia">
-```jl
-M.my_table()
-```
-</pre>
+    ```jl
+    M.my_table()
+    ```
 
 Then, it will show as
 
@@ -143,17 +141,17 @@ Most things can be done via functions.
 However, defining a struct is not possible, because `@sco` cannot locate the struct definition inside the module.
 Therefore, it is also possible to pass code and specify that you want to evaluate and show code (sc) without showing the output:
 
-<pre class="language-julia">
-```jl
-s = """
-    struct Point
-        x
-        y
-    end
-    """
-sc(s)
-```
-</pre>
+    ```jl
+    s = """
+        struct Point
+            x
+            y
+        end
+        """
+    sc(s)
+    ```
+
+which shows as
 
 ```jl
 s = """
@@ -168,11 +166,9 @@ sc(s)
 and show code and output (sco).
 For example,
 
-<pre class="language-julia">
-```jl
-sco("p = Point(1, 2)")
-```
-</pre>
+    ```jl
+    sco("p = Point(1, 2)")
+    ```
 
 shows as
 
@@ -182,11 +178,9 @@ sco("p = Point(1, 2)")
 
 Note that this is starting to look a lot like R Markdown where the syntax would be something like
 
-<pre class="language-julia">
-```{r, results='hide'}
-x = rnorm(100)
-```
-</pre>
+    ```{r, results='hide'}
+    x = rnorm(100)
+    ```
 
 I guess that there is no perfect way here.
 The benefit of evaluating the user input directly, as Books.jl is doing, seems to be that it is more extensible if I'm not mistaken.
@@ -230,11 +224,9 @@ For example, inside our package, we can define the following method:
 To show code and output (sco) for this method, use the `@sco` macro.
 This macro is exported by Books, so ensure that you have `using Books` in your package.
 
-<pre class="language-julia">
-```jl
-@sco M.my_data()
-```
-</pre>
+    ```jl
+    @sco M.my_data()
+    ```
 
 This gives
 
@@ -244,11 +236,9 @@ This gives
 
 To only show the source code, use `@sc`:
 
-<pre class="language-julia">
-```jl
-@sc M.my_data()
-```
-</pre>
+    ```jl
+    @sc M.my_data()
+    ```
 
 resulting in
 
@@ -258,15 +248,13 @@ resulting in
 
 To override options for your output, use the `pre` keyword argument of `@sco`:
 
-<pre class="language-julia">
-```jl
-let
-    caption = "This caption is set via the pre keyword."
-    pre(out) = Options(out; caption)
-    @sco pre=pre my_data()
-end
-```
-</pre>
+    ```jl
+    let
+        caption = "This caption is set via the pre keyword."
+        pre(out) = Options(out; caption)
+        @sco pre=pre my_data()
+    end
+    ```
 
 which appears to the reader as:
 
@@ -282,11 +270,9 @@ See `?sco` for more information.
 Since we're using methods as code blocks, we can use the code shown in one code block in another.
 For example, to determine the mean of column A:
 
-<pre class="language-julia">
-```jl
-@sco M.my_data_mean(my_data())
-```
-</pre>
+    ```jl
+    @sco M.my_data_mean(my_data())
+    ```
 
 shows as
 
@@ -303,11 +289,9 @@ Or, we can show the output inline, namely `jl M.my_data_mean(my_data())`, by usi
 It is also possible to show methods with parameters.
 For example,
 
-<pre class="language-julia">
-```jl
-@sc M.hello("" )
-```
-</pre>
+    ```jl
+    @sc M.hello("" )
+    ```
 
 shows
 
@@ -367,12 +351,10 @@ And, for adjusting the caption, use `Options`:
 
 or the caption can be specified in the Markdown file:
 
-<pre class="language-julia">
-```jl
-p = M.image_options_plot()
-Options(p; caption="Label specified in Markdown.")
-```
-</pre>
+    ```jl
+    p = M.image_options_plot()
+    Options(p; caption="Label specified in Markdown.")
+    ```
 
 ```jl
 p = M.image_options_plot()
@@ -459,12 +441,10 @@ scob("s = \"Hello\"")
 
 Another way to change the output is via the keyword arguments `process` and `post` for `sco`.
 
-<pre class="language-julia">
-```jl
-s = "df = DataFrame(A = [1], B = [Date(2018)])"
-sco(s; process=string, post=output_block)
-```
-</pre>
+    ```jl
+    s = "df = DataFrame(A = [1], B = [Date(2018)])"
+    sco(s; process=string, post=output_block)
+    ```
 
 which shows the following to the reader:
 
@@ -493,11 +473,9 @@ sco(s; process=string)
 This also works for `@sco`.
 For example, for `my_data` we can use:
 
-<pre class="language-julia">
-```jl
-@sco process=string post=output_block my_data()
-```
-</pre>
+    ```jl
+    @sco process=string post=output_block my_data()
+    ```
 
 which will show as:
 

--- a/docs/contents/demo.md
+++ b/docs/contents/demo.md
@@ -18,11 +18,9 @@ $$ y = \frac{\sin{x}}{\cos{x}} $$ {#eq:example}
 For embedding code, you can use the `jl` inline code or code block.
 For example, to show the Julia version, define a code block like
 
-<pre>
-```jl
-M.julia_version()
-```
-</pre>
+    ```jl
+    M.julia_version()
+    ```
 
 in a Markdown file.
 Then, in your package, define the method `julia_version()`:

--- a/docs/contents/getting-started.md
+++ b/docs/contents/getting-started.md
@@ -87,9 +87,9 @@ M.default_config()
 Here, the `extra_directories` allows you to specify directories which need to be moved into `_build`, which makes them available for the local server and online.
 This is, for instance, useful for images like @fig:store:
 
-<pre class="language-markdown">
-![Book store.](images/book-store.jpg){#fig:book_store}
-</pre>
+    ![Book store.](images/book-store.jpg){#fig:book_store}
+
+shows as
 
 ![Book store.](images/book-store.jpg){#fig:store}
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -92,8 +92,13 @@ end
 
 function codeblock2output(s::AbstractString)
     expr = s
-    @show s
+    # Hacky way to ignore code blocks with four spaces.
+    # Cleaner would be to improve the regex.
+    if endswith(s, "    ```\n")
+        return s
+    end
     expr = strip(expr)
+    # Remove start and end of code block.
     expr = expr[7:end-4]
     expr = strip(expr)
     output_path = escape_expr(expr)

--- a/src/build.jl
+++ b/src/build.jl
@@ -92,6 +92,7 @@ end
 
 function codeblock2output(s::AbstractString)
     expr = s
+    @show s
     expr = strip(expr)
     expr = expr[7:end-4]
     expr = strip(expr)

--- a/src/build.jl
+++ b/src/build.jl
@@ -94,7 +94,7 @@ function codeblock2output(s::AbstractString)
     expr = s
     # Hacky way to ignore code blocks with four spaces.
     # Cleaner would be to improve the regex.
-    if endswith(s, "    ```\n")
+    if endswith(s, "\n    ```\n")
         return s
     end
     expr = strip(expr)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -28,8 +28,11 @@ output_block(s) = "```output\n$s\n```\n"
     CODEBLOCK_PATTERN
 
 Pattern to match `jl` code blocks.
+
+This pattern also, wrongly, matches blocks indented with four spaces.
+These are ignored after matching.
 """
-const CODEBLOCK_PATTERN = r"```jl\s*([^```]*)\n([ ]*)```\n(?!</pre>)"
+const CODEBLOCK_PATTERN = r"```jl\s*([^```]*)\n([ ]*)```\n"
 
 const INLINE_CODEBLOCK_PATTERN = r" `jl ([^`]*)`"
 
@@ -65,6 +68,7 @@ function extract_expr(s::AbstractString)::Vector
     matches = eachmatch(CODEBLOCK_PATTERN, s)
     function clean(m)
         expr = m[1]::SubString{String}
+        @show expr
         expr = strip(expr)
         expr = string(expr)::String
         indentation = if haskey(m, 2)
@@ -76,6 +80,9 @@ function extract_expr(s::AbstractString)::Vector
         return UserExpr(expr, indentation)
     end
     from_codeblocks = clean.(matches)
+    # These blocks are used in the Books.jl documentation.
+    filter!(e -> e.indentation != 4, from_codeblocks)
+
     matches = eachmatch(INLINE_CODEBLOCK_PATTERN, s)
     from_inline = clean.(matches)
     exprs = [from_codeblocks; from_inline]
@@ -88,7 +95,7 @@ function extract_expr(s::AbstractString)::Vector
         end
     end
     check_parse_errors.(exprs)
-    exprs
+    return exprs
 end
 
 """

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -68,7 +68,6 @@ function extract_expr(s::AbstractString)::Vector
     matches = eachmatch(CODEBLOCK_PATTERN, s)
     function clean(m)
         expr = m[1]::SubString{String}
-        @show expr
         expr = strip(expr)
         expr = string(expr)::String
         indentation = if haskey(m, 2)

--- a/src/output.jl
+++ b/src/output.jl
@@ -382,9 +382,7 @@ function docstring(s::MD)
     # lines = ["> $line" for line in lines]
     text = join(lines, '\n')
     """
-    <pre>
-    $text
-    </pre>
+        $text
     """
 end
 

--- a/test/build.jl
+++ b/test/build.jl
@@ -98,4 +98,12 @@
         lines = split(out, '\n')
         @test lines[1] == "Ans: 2."
     end
+
+    # Four indentations.
+    not_evaluated_block = """
+            ```jl
+            1 + 1
+            ```
+        """
+    out = Books.embed_output(not_evaluated_block)
 end

--- a/test/build.jl
+++ b/test/build.jl
@@ -102,8 +102,10 @@
     # Four indentations.
     not_evaluated_block = """
             ```jl
-            1 + 1
+            x = 1 + 1
+            y = 2 + 2
             ```
         """
     out = Books.embed_output(not_evaluated_block)
+    @test out == "    ```jl\n    x = 1 + 1\n    y = 2 + 2\n    ```\n"
 end

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -31,54 +31,54 @@ using DataFrames
         |   1 |"""
 
 
-    valid_block = """
+    evaluated_block = """
         ```jl
         foo
         ```
         """
-    @test match(Books.CODEBLOCK_PATTERN, valid_block)[1] == "foo"
+    @test match(Books.CODEBLOCK_PATTERN, evaluated_block)[1] == "foo"
 
-    invalid_block = """
-        <pre>
-        ```jl
-        foo
-        ```
-        </pre>
+    # Three indentations should be evaluated.
+    evaluated_block = """
+           ```jl
+           foo
+           ```
         """
-    @test match(Books.CODEBLOCK_PATTERN, invalid_block) === nothing
+    @test match(Books.CODEBLOCK_PATTERN, evaluated_block)[1] == "foo"
 
-    invalid_block = """
-        <pre class="language-julia">
-        ```jl
-        x = 1 + 1
-        ```
-        </pre>
-        which is displayed as
-        ```jl
-        x = 1 + 1
-        ```
-        """
-    @test !contains(match(Books.CODEBLOCK_PATTERN, invalid_block).match, "pre")
+    function read_outcome(block::AbstractString)
+        cd(joinpath(Books.PROJECT_ROOT, "docs")) do
+            exprs = Books.extract_expr(block)
+            userexpr = first(exprs)
+            Books.evaluate_and_write(Main, userexpr)
+            path = Books.escape_expr(userexpr.expr)
+            out = read(path, String)
+            return out
+        end
+    end
 
-    valid_block = """
+    evaluated_block = """
         1. This is a code block in a list with 3 spaces indentation because Pandoc would see it as a nested level otherwise.
            ```jl
            s = "x = 1"
            sco(s)
            ```
         """
-    m = match(Books.CODEBLOCK_PATTERN, valid_block)
+    m = match(Books.CODEBLOCK_PATTERN, evaluated_block)
     @test m[1] == "s = \"x = 1\"\n   sco(s)"
     @test m[2] == "   "
 
-    out = cd(joinpath(Books.PROJECT_ROOT, "docs")) do
-        userexpr = first(Books.extract_expr(valid_block))
-        Books.evaluate_and_write(Main, userexpr)
-        path = Books.escape_expr(userexpr.expr)
-        out = read(path, String)
-        return out
-    end
+    out = read_outcome(evaluated_block)
     @test out == "   ```language-julia\n   x = 1\n   ```\n   \n   1\n   "
+
+    # Blocks with four indentations should not be evaluated.
+    # This functionality is useful for the Books.jl documentation.
+    not_evaluated_block = """
+            ```jl
+            1 + 1
+            ```
+        """
+    @test isempty(Books.extract_expr(not_evaluated_block))
 end
 
 module Foo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,10 @@ if VERSION in Pkg.Types.VersionRange(v"1.6", v"1.6.10")
 end
 
 @testset "Books.jl" begin
-    include("output.jl")
-    include("build.jl")
-    include("html.jl")
-    include("showcode.jl")
-    include("sitemap.jl")
+    # include("output.jl")
+    # include("build.jl")
+    # include("html.jl")
+    # include("showcode.jl")
+    # include("sitemap.jl")
     include("generate.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,10 @@ if VERSION in Pkg.Types.VersionRange(v"1.6", v"1.6.10")
 end
 
 @testset "Books.jl" begin
-    # include("output.jl")
-    # include("build.jl")
-    # include("html.jl")
-    # include("showcode.jl")
-    # include("sitemap.jl")
+    include("output.jl")
+    include("build.jl")
+    include("html.jl")
+    include("showcode.jl")
+    include("sitemap.jl")
     include("generate.jl")
 end


### PR DESCRIPTION
Ignore evaluation of code blocks with four indentations. A feature which is probably only useful for the Books.jl documentation.

This replaces the usage of the `<pre>` block, because those only end up in the HTML output.

- Fix #220. 